### PR TITLE
Multi workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ graph TB
 
 ## 🖥 Cluster Configuration
 
-> **Note about IP Addressing**: This configuration uses `192.168.63.1` and `192.168.63.2` for the control plane and worker nodes respectively. You can modify these IPs in the `Vagrantfile` to use any IP addresses from your router's IP range that are outside the DHCP scope. Make sure to choose IPs that won't conflict with other devices on your network.
+> **Note about IP Addressing**: This configuration uses `192.168.63.11` and `192.168.63.12` for the control plane and worker nodes respectively. You can modify these IPs in the `Vagrantfile` to use any IP addresses from your router's IP range that are outside the DHCP scope. Make sure to choose IPs that won't conflict with other devices on your network.
 
 <table>
 <tr>
@@ -82,7 +82,7 @@ graph TB
 <td>
 
 ```yaml
-IP: 192.168.63.1
+IP: 192.168.63.11
 Hostname: cplane
 Memory: 2048MB
 CPUs: 2
@@ -93,7 +93,7 @@ Role: Control Plane
 <td>
 
 ```yaml
-IP: 192.168.63.2
+IP: 192.168.63.12
 Hostname: worker
 Memory: 2048MB
 CPUs: 2
@@ -110,7 +110,7 @@ Role: Worker
 
 ## Quick Start
 
-> **💡 Tip**: Before starting, you may want to adjust the IP addresses in the `Vagrantfile` if the default IPs (`192.168.63.1, 192.168.63.2`) conflict with your network setup. Edit the `private_network` IP settings in the Vagrantfile to match your network requirements.
+> **💡 Tip**: Before starting, you may want to adjust the IP addresses in the `Vagrantfile` if the default IPs (`192.168.63.11, 192.168.63.12`) conflict with your network setup. Edit the `private_network` IP settings in the Vagrantfile to match your network requirements.
 
 1. Clone this repository:
 ```bash
@@ -177,7 +177,7 @@ sudo kubeadm config images pull
 
 Initialize the cluster:
 ```bash
-sudo kubeadm init --pod-network-cidr=10.201.0.0/16 --apiserver-advertise-address=192.168.63.1
+sudo kubeadm init --pod-network-cidr=10.201.0.0/16 --apiserver-advertise-address=192.168.63.11
 ```
 
 ### 2. Install CNI (Container Network Interface)

--- a/README.md
+++ b/README.md
@@ -195,14 +195,9 @@ For ease of use, a single script `cluster_init.sh` was created as a function of 
 * local copy of "kube config"
 * Weave CNI install
 
-First, log into the control plane node:
+and can be run with the vagrant command:
 ```bash
-vagrant ssh cplane
-```
-
-Run the Cluster Init Script:
-```bash
-./cluster_init.sh
+vagrant ssh cplane -c "./cluster_init.sh"
 ```
 
 ### 3. Join Worker Node

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)](https://kubernetes.io/)
 [![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)](https://ubuntu.com/)
 
-This project sets up a local Kubernetes cluster using Vagrant and VirtualBox. It creates two Ubuntu 22.04 virtual machines: one control plane node and one worker node with automatic installation of Docker, Kubernetes components, and necessary configurations.
+This project sets up a local Kubernetes cluster using Vagrant and VirtualBox. It creates two Ubuntu 24.04 virtual machines: one control plane node and one worker node with automatic installation of Docker, Kubernetes components, and necessary configurations.
 
 ## Architecture
 
@@ -45,7 +45,7 @@ graph TB
 <table>
 <tr>
     <td align="center">🔄</td>
-    <td>Automated VM provisioning with Ubuntu 22.04</td>
+    <td>Automated VM provisioning with Ubuntu 24.04</td>
 </tr>
 <tr>
     <td align="center">🌐</td>

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 [![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)](https://kubernetes.io/)
 [![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)](https://ubuntu.com/)
 
-This project sets up a local Kubernetes cluster using Vagrant and VirtualBox. It creates two Ubuntu 22.04 virtual machines: one master node and one worker node with automatic installation of Docker, Kubernetes components, and necessary configurations.
+This project sets up a local Kubernetes cluster using Vagrant and VirtualBox. It creates two Ubuntu 22.04 virtual machines: one control plane node and one worker node with automatic installation of Docker, Kubernetes components, and necessary configurations.
 
 ## Architecture
 
 ```mermaid
 graph TB
     subgraph Vagrant-Managed Environment
-        subgraph Master Node
+        subgraph Control Plane Node
             A[Control Plane] --> B[API Server]
             B --> C[etcd]
             B --> D[Controller Manager]
@@ -25,7 +25,7 @@ graph TB
         B <-.-> F
         B <-.-> H
     end
-    style Master Node fill:#f9f,stroke:#333,stroke-width:2px
+    style Control Plane Node fill:#f9f,stroke:#333,stroke-width:2px
     style Worker Node fill:#bbf,stroke:#333,stroke-width:2px
 ```
 
@@ -71,11 +71,11 @@ graph TB
 
 ## 🖥 Cluster Configuration
 
-> **Note about IP Addressing**: This configuration uses `192.168.63.1` and `192.168.63.2` for the master and worker nodes respectively. You can modify these IPs in the `Vagrantfile` to use any IP addresses from your router's IP range that are outside the DHCP scope. Make sure to choose IPs that won't conflict with other devices on your network.
+> **Note about IP Addressing**: This configuration uses `192.168.63.1` and `192.168.63.2` for the control plane and worker nodes respectively. You can modify these IPs in the `Vagrantfile` to use any IP addresses from your router's IP range that are outside the DHCP scope. Make sure to choose IPs that won't conflict with other devices on your network.
 
 <table>
 <tr>
-    <th width="50%">Master Node</th>
+    <th width="50%">Control Plane Node</th>
     <th width="50%">Worker Node</th>
 </tr>
 <tr>
@@ -83,7 +83,7 @@ graph TB
 
 ```yaml
 IP: 192.168.63.1
-Hostname: master
+Hostname: cplane
 Memory: 2048MB
 CPUs: 2
 Role: Control Plane
@@ -123,9 +123,9 @@ cd vagrant
 vagrant up
 ```
 
-3. SSH into the master node:
+3. SSH into the control plane node:
 ```bash
-vagrant ssh master
+vagrant ssh cplane
 ```
 
 4. SSH into the worker node:
@@ -163,11 +163,11 @@ vagrant destroy
 
 After the VMs are up and running, follow these steps to initialize your Kubernetes cluster:
 
-### 1. On Master Node
+### 1. On Control Plane Node
 
-First, log into the master node:
+First, log into the control plane node:
 ```bash
-vagrant ssh master
+vagrant ssh cplane
 ```
 
 Pull required Kubernetes images:
@@ -187,13 +187,38 @@ After the cluster initialization, install Weave CNI:
 kubectl apply -f https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml
 ```
 
+### NOTE: Control Plane script 'cluster_init.sh' wraps steps 1. and 2.
+
+For ease of use, a single script `cluster_init.sh` was created as a function of the "vagrant up" command for the control plane(s) that performs all of the above steps:
+* k8s image pull
+* kubeadm init
+* local copy of "kube config"
+* Weave CNI install
+
+First, log into the control plane node:
+```bash
+vagrant ssh cplane
+```
+
+Run the Cluster Init Script:
+```bash
+./cluster_init.sh
+```
+
 ### 3. Join Worker Node
 
-Copy the `kubeadm join` command from the master node's initialization output and run it on the worker node with sudo privileges.
+Copy the `kubeadm join` command from the control plane node's initialization output and run it on the worker node with sudo privileges.
+
+### NOTE: Control Plane script 'join_cmd.sh' shows the 'join' command
+
+For ease of use, script `join_cmd.sh` was created to display the join command for use on worker nodes with this vagrant command:
+```bash
+vagrant ssh cplane -c "./join_cmd.sh"
+```
 
 ### 4. Verify Cluster Status
 
-After joining the worker node, verify the cluster status from the master node:
+After joining the worker node, verify the cluster status from the control plane node:
 
 ```bash
 # Check node status
@@ -203,7 +228,7 @@ kubectl get nodes
 Expected output (it may take a few minutes for the nodes to be ready):
 ```
 NAME     STATUS   ROLES           AGE     VERSION
-master   Ready    control-plane   5m32s   v1.30.x
+cplane   Ready    control-plane   5m32s   v1.30.x
 worker   Ready    <none>          2m14s   v1.30.x
 ```
 
@@ -228,7 +253,7 @@ sudo systemctl restart containerd
 sudo systemctl daemon-reload
 ```
 
-3. After cleanup, retry the cluster initialization on master and join command on worker.
+3. After cleanup, retry the cluster initialization on the cplane and join command on worker.
 
 ## Default Credentials
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,7 @@ Vagrant.configure("2") do |config|
     config.vm.define node[:name] do |cplane|
       cplane.vm.box = node[:box]
       cplane.vm.network node[:network], ip: node[:ip]
+      cplane.vm.network "forwarded_port", guest: 443, host: 8443 # Port Forward for k8s dashboard
       cplane.vm.hostname = node[:name]
       cplane.vm.provider "virtualbox" do |v|
         v.name = node[:name]
@@ -94,6 +95,13 @@ Vagrant.configure("2") do |config|
 
         # apt-transport-https may be a dummy package; if so, you can skip that package
         sudo apt install -y apt-transport-https ca-certificates curl gpg
+        # Helm Deployment Manager
+        curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+        sudo apt update
+        sudo apt install -y helm
+
+        # Containerd
         curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
         echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
         sudo apt update

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # Configuration parameters
 VAGRANT_BASE_OS = "bento/ubuntu-24.04" # "bento/ubuntu-22.04"
-PRIVATE_NETWORK = "private_network"    # For Host -> VM and VM <-> VM within the network
+PRIVATE_NETWORK = "private_network"    # For Host -> VM and VM <-> VM (within the network)
 BASE_CIDR       = "10.201.0.0"         # Base address for pods
 
 # Create list of one or more Control Plane Nodes (but one is sufficient)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,93 +1,150 @@
-Vagrant.configure("2") do |config|
-  # Define master VM
-  config.vm.define "master" do |master|
-    master.vm.box = "bento/ubuntu-22.04"
-    master.vm.network "private_network", ip: "192.168.63.1"
-    master.vm.hostname = "master"
-    master.vm.provider "virtualbox" do |v|
-      v.name = "master"
-      v.memory = 2048
-      v.cpus = 2
-    end
-    master.vm.provision "shell", inline: <<-SHELL
-      sudo echo "192.168.63.1 master\n192.168.63.2 worker" >> /etc/hosts
-      sudo apt update
-      sudo apt install ca-certificates curl
-      sudo install -m 0755 -d /etc/apt/keyrings
-      sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-      sudo chmod a+r /etc/apt/keyrings/docker.asc
+# Configuration parameters
+VAGRANT_BASE_OS = "bento/ubuntu-24.04" # "bento/ubuntu-22.04"
+PRIVATE_NETWORK = "private_network"
+BASE_CIDR = "10.148.0.0"         # Base address for pods
+CLUSTER_BASE_IP = "192.168.63.1"       # Base address for nodes
 
-      # Add the repository to Apt sources:
-      echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-      sudo apt update
-      sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-      sudo systemctl enable docker
-      sudo ufw disable
-      sudo swapoff -a
-      sudo apt update && sudo apt install -y apt-transport-https
-      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-      sudo apt update
-      # apt-transport-https may be a dummy package; if so, you can skip that package
-      sudo apt install -y apt-transport-https ca-certificates curl gpg
-      curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-      echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
-      sudo apt update
-      sudo apt install -y kubelet kubeadm kubectl
-      sudo apt-mark hold kubelet kubeadm kubectl
-      sudo systemctl enable --now kubelet
-      sudo containerd config default | sudo tee /etc/containerd/config.toml
-      sudo sed -i 's/            SystemdCgroup = false/            SystemdCgroup = true/' /etc/containerd/config.toml
-      sudo sed -i 's|sandbox_image = "registry.k8s.io/pause:3.8"|sandbox_image = "registry.k8s.io/pause:3.9"|g' /etc/containerd/config.toml
-      sudo systemctl restart containerd
-      SHELL
+# Create list of one or more Control Plane Nodes (but one is sufficient)
+CPLANE_NODES = [
+  { name: "cplane",    box: VAGRANT_BASE_OS, network: PRIVATE_NETWORK, ip: "192.168.63.11" }
+]
+
+# Create list of one or more worker nodes
+# Mindful of the 'name' and 'ip' values for each
+WORKER_NODES = [
+  { name: "worker1", box: VAGRANT_BASE_OS, network: PRIVATE_NETWORK, ip: "192.168.63.12" }
+]
+
+# Work out the "/etc/hosts" values to get copied in each node (cplanes and workers)
+ALL_NODES = CPLANE_NODES + WORKER_NODES
+ETC_HOSTS = ALL_NODES.map { |n| "#{n[:ip]} #{n[:name]}" }.join("\n") + "\n"
+
+Vagrant.configure("2") do |config|
+  # Define Control Plane Nodes
+  CPLANE_NODES.each do |node|
+    config.vm.define node[:name] do |cplane|
+      cplane.vm.box = node[:box]
+      cplane.vm.network node[:network], ip: node[:ip]
+      cplane.vm.hostname = node[:name]
+      cplane.vm.provider "virtualbox" do |v|
+        v.name = node[:name]
+        v.memory = 2048
+        v.cpus = 2
+      end
+      cplane.vm.provision "shell",
+        env: {
+          "ETC_HOSTS"       => ETC_HOSTS,
+          "BASE_CIDR"       => BASE_CIDR,
+          "CLUSTER_BASE_IP" => CLUSTER_BASE_IP
+        },
+        inline: <<-SHELL
+        # Add Nodes to /etc/hosts
+        sudo echo "# Added by Vagrant" >> /etc/hosts
+        sudo echo "#" >> /etc/hosts
+        echo -e "${ETC_HOSTS}" | while read -r hline; do
+          sudo echo ${hline} >> /etc/hosts
+        done
+        # Create Cluster Init Script:
+        sudo echo "#!/bin/bash"                     >  cluster_init.sh
+        sudo echo "echo 'Pulling K8s Images'"       >> cluster_init.sh
+        sudo echo "sudo kubeadm config images pull" >> cluster_init.sh
+        sudo echo "echo '\nInitializing Cluster'"   >> cluster_init.sh
+        sudo echo "sudo kubeadm init --pod-network-cidr=${BASE_CIDR}/16 --apiserver-advertise-address=${CLUSTER_BASE_IP}" >> cluster_init.sh
+        sudo chmod a+rx cluster_init.sh
+        # Create Weave Install Script:
+        sudo echo "#!/bin/bash"           >  weave_install.sh
+        sudo echo "echo 'Install Weave'"  >> weave_install.sh
+        sudo echo "kubectl apply -f https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml" >> weave_install.sh
+        sudo chmod a+rx weave_install.sh
+        # Apt Stuff:
+        sudo apt update
+        sudo apt install ca-certificates curl
+        sudo install -m 0755 -d /etc/apt/keyrings
+        sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+        # Add the repository to Apt sources:
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt update
+        sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        sudo systemctl enable docker
+        sudo ufw disable
+        sudo swapoff -a
+        sudo apt update && sudo apt install -y apt-transport-https
+        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+        sudo apt update
+        # apt-transport-https may be a dummy package; if so, you can skip that package
+        sudo apt install -y apt-transport-https ca-certificates curl gpg
+        curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+        echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+        sudo apt update
+        sudo apt install -y kubelet kubeadm kubectl
+        sudo apt-mark hold kubelet kubeadm kubectl
+        sudo systemctl enable --now kubelet
+        sudo containerd config default | sudo tee /etc/containerd/config.toml
+        sudo sed -i 's/            SystemdCgroup = false/            SystemdCgroup = true/' /etc/containerd/config.toml
+        sudo sed -i 's|sandbox_image = "registry.k8s.io/pause:3.8"|sandbox_image = "registry.k8s.io/pause:3.9"|g' /etc/containerd/config.toml
+        sudo systemctl restart containerd
+        SHELL
+    end
   end
 
-  # Define worker VM
-  config.vm.define "worker" do |worker|
-    worker.vm.box = "bento/ubuntu-22.04"
-    worker.vm.network "private_network", ip: "192.168.63.2"
-    worker.vm.hostname = "worker"
-    worker.vm.provider "virtualbox" do |v|
-      v.name = "worker"
-      v.memory = 2048
-      v.cpus = 2
-    end
-    worker.vm.provision "shell", inline: <<-SHELL
-      sudo echo "192.168.63.1 master\n192.168.63.2 worker" >> /etc/hosts
-      sudo apt update
-      sudo apt install ca-certificates curl
-      sudo install -m 0755 -d /etc/apt/keyrings
-      sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-      sudo chmod a+r /etc/apt/keyrings/docker.asc
+  # Define Worker Nodes
+  WORKER_NODES.each do |node|
+    config.vm.define node[:name] do |worker|
+      worker.vm.box = node[:box]
+      worker.vm.network node[:network], ip: node[:ip]
+      worker.vm.hostname = node[:name]
+      worker.vm.provider "virtualbox" do |v|
+        v.name = node[:name]
+        v.memory = 2048
+        v.cpus = 2
+      end
+      worker.vm.provision "shell",
+        env: {"ETC_HOSTS" => ETC_HOSTS},
+        inline: <<-SHELL
+        # Add Nodes to /etc/hosts
+        sudo echo "# Added by Vagrant" >> /etc/hosts
+        sudo echo "#" >> /etc/hosts
+        echo -e "${ETC_HOSTS}" | while read -r hline; do
+          sudo echo ${hline} >> /etc/hosts
+        done
+        # Apt Stuff:
+        sudo apt update
+        sudo apt install ca-certificates curl
+        sudo install -m 0755 -d /etc/apt/keyrings
+        sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        sudo chmod a+r /etc/apt/keyrings/docker.asc
 
-      # Add the repository to Apt sources:
-      echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-      sudo apt update
-      sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-      sudo systemctl enable docker
-      sudo ufw disable
-      sudo swapoff -a
-      sudo apt update && sudo apt install -y apt-transport-https
-      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-      sudo apt update
-      # apt-transport-https may be a dummy package; if so, you can skip that package
-      sudo apt install -y apt-transport-https ca-certificates curl gpg
-      curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-      echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
-      sudo apt update
-      sudo apt install -y kubelet kubeadm kubectl
-      sudo apt-mark hold kubelet kubeadm kubectl
-      sudo systemctl enable --now kubelet
-      sudo containerd config default | sudo tee /etc/containerd/config.toml
-      sudo sed -i 's/            SystemdCgroup = false/            SystemdCgroup = true/' /etc/containerd/config.toml
-      sudo sed -i 's|sandbox_image = "registry.k8s.io/pause:3.8"|sandbox_image = "registry.k8s.io/pause:3.9"|g' /etc/containerd/config.toml
-      sudo systemctl restart containerd
-      SHELL
+        # Add the repository to Apt sources:
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt update
+        sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        sudo systemctl enable docker
+        sudo ufw disable
+        sudo swapoff -a
+        sudo apt update && sudo apt install -y apt-transport-https
+        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+        sudo apt update
+        # apt-transport-https may be a dummy package; if so, you can skip that package
+        sudo apt install -y apt-transport-https ca-certificates curl gpg
+        curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+        echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+        sudo apt update
+        sudo apt install -y kubelet kubeadm kubectl
+        sudo apt-mark hold kubelet kubeadm kubectl
+        sudo systemctl enable --now kubelet
+        sudo containerd config default | sudo tee /etc/containerd/config.toml
+        sudo sed -i 's/            SystemdCgroup = false/            SystemdCgroup = true/' /etc/containerd/config.toml
+        sudo sed -i 's|sandbox_image = "registry.k8s.io/pause:3.8"|sandbox_image = "registry.k8s.io/pause:3.9"|g' /etc/containerd/config.toml
+        sudo systemctl restart containerd
+        SHELL
+    end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # Configuration parameters
 VAGRANT_BASE_OS = "bento/ubuntu-24.04" # "bento/ubuntu-22.04"
 PRIVATE_NETWORK = "private_network"
-BASE_CIDR = "10.148.0.0"         # Base address for pods
+BASE_CIDR = "10.201.0.0"         # Base address for pods
 CLUSTER_BASE_IP = "192.168.63.1"       # Base address for nodes
 
 # Create list of one or more Control Plane Nodes (but one is sufficient)
@@ -46,9 +46,10 @@ Vagrant.configure("2") do |config|
         done
         # Create Cluster Init Script:
         sudo echo "#!/bin/bash"                     >  cluster_init.sh
-        sudo echo "echo 'Pulling K8s Images'"       >> cluster_init.sh
+        sudo echo "echo 'Pulling k8s Images'"       >> cluster_init.sh
         sudo echo "sudo kubeadm config images pull" >> cluster_init.sh
-        sudo echo "echo '\nInitializing Cluster'"   >> cluster_init.sh
+        sudo echo "echo ''"                         >> cluster_init.sh
+        sudo echo "echo 'Initializing Cluster'"     >> cluster_init.sh
         sudo echo "sudo kubeadm init --pod-network-cidr=${BASE_CIDR}/16 --apiserver-advertise-address=${CLUSTER_BASE_IP}" >> cluster_init.sh
         sudo chmod a+rx cluster_init.sh
         # Create Weave Install Script:


### PR DESCRIPTION
list of workers, and other additions

- Add commonly-configured values into variables at the top of the script for ease of understanding and to separate consistent vs changeable config (a good devOps practice)
- refactored control plane and worker configurations into lists, in order to make it easier to have multiple worker nodes
- dynamic creation / management of '/etc/hosts' entries based upon the cplane/worker lists above, removing hard coding and supprting the "multi-worker" list mentioned above
- aggregated the control plane node initiation steps into a single script `cluster_init.sh`, increasing usability by not having the user required to manually type in all the commands
- added a `join_cmd.sh` script in the control plane node to make it easier to find the proper join key

