### PR TITLE
Refactor; introduce scripts, kube dashboard installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ graph TB
     <td>Ready-to-use Kubernetes cluster setup</td>
 </tr>
 <tr>
+    <td align="center">📜</td>
+    <td>Easy-to-use Bash Scripts for Kubernetes cluster setup - reduce typing errors</td>
+</tr>
+
+<tr>
     <td align="center">🔒</td>
     <td>Secure communication between nodes</td>
 </tr>
@@ -177,14 +182,30 @@ sudo kubeadm config images pull
 
 Initialize the cluster:
 ```bash
-sudo kubeadm init --pod-network-cidr=10.201.0.0/16 --apiserver-advertise-address=192.168.63.11
+sudo kubeadm init --pod-network-cidr=10.244.0.0/16 --apiserver-advertise-address=192.168.63.11
 ```
 
-### 2. Install CNI (Container Network Interface)
+### 2a. Install Weave CNI (Container Network Interface)
 
 After the cluster initialization, install Weave CNI:
 ```bash
 kubectl apply -f https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml
+```
+
+### NOTE: Weave CNI has been discontinued
+
+With the shutdown of Weaveworks, Weave CNI has been effectively discontinued, the GitHub repo archived in June 2024. So a new CNI should be considered, and the first suggestion is Flannel
+
+### 2b. Install Flannel CNI (Container Network Interface)
+
+First, install Flannel CNI:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml 
+```
+
+Then, restart the Kublet service:
+```bash
+sudo service kubelet restart
 ```
 
 ### NOTE: Control Plane script 'cluster_init.sh' wraps steps 1. and 2.
@@ -228,6 +249,40 @@ worker   Ready    <none>          2m14s   v1.30.x
 ```
 
 > **Note**: The nodes may show `NotReady` status initially as the CNI (Container Network Interface) is being configured. Please wait a few minutes for the status to change to `Ready`.
+
+### 5. (Optional) Set Role for Worker Node(s)
+
+As the output above shows, there is no initial role set for worker nodes.  You can set their role to "worker" with:
+
+The Kubernetes Dashboard is Web UI that allows you to manage your cluster; configure and manage aspects of the system, troubleshoot, and to have an overview of applications running on your cluster
+
+```bash
+vagrant ssh cplane -c "./set_worker_role.sh"
+```
+
+This script can be run any time a new node is added.
+
+### 6. (Optional) Kubernetes Dashboard Installation
+
+The Kubernetes Dashboard is Web UI that allows you to manage your cluster; configure and manage aspects of the system, troubleshoot, and to have an overview of applications running on your cluster
+
+First, log into the control plane node:
+```bash
+vagrant ssh cplane
+```
+
+Execute the Dashboard setup script:
+```bash
+./kub_dashboard.sh <option>
+```
+
+Where `<option>` is one of:
+* worker - to deploy dashboard on any worker node
+* cplane - to deploy dashboard on the control plane
+* token  - to show the dashboard credentials token (and the dashboard url)
+
+Normally, the Kubernetes Dashboard would be deployed to one of the worker nodes.  This would always be the case in a production
+Kubernetes cluster.  However for a small development cluster, it doesn't hurt to run the dashboard on the control plane
 
 ### Troubleshooting
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,6 @@
 # Configuration parameters
-VAGRANT_BASE_OS = "bento/ubuntu-24.04" # "bento/ubuntu-22.04"
+VAGRANT_BASE_OS = "bento/ubuntu-24.04"
 PRIVATE_NETWORK = "private_network"    # For Host -> VM and VM <-> VM (within the network)
-BASE_CIDR       = "10.201.0.0"         # Base address for pods
 
 # Create list of one or more Control Plane Nodes (but one is sufficient)
 CPLANE_NODES = [
@@ -12,9 +11,11 @@ CPLANE_NODES = [
 # Mindful of the 'name' and 'ip' values for each
 WORKER_NODES = [
   { name: "worker1", box: VAGRANT_BASE_OS, network: PRIVATE_NETWORK, ip: "192.168.63.12" }
+#  { name: "worker1", box: VAGRANT_BASE_OS, network: PRIVATE_NETWORK, ip: "192.168.63.12" },
+#  { name: "worker2", box: VAGRANT_BASE_OS, network: PRIVATE_NETWORK, ip: "192.168.63.13" }
 ]
 
-# Work out the "/etc/hosts" values to get copied in each node (cplanes and workers)
+# Work out the "/etc/hosts" values to be copied in each node (cplanes and workers)
 ALL_NODES = CPLANE_NODES + WORKER_NODES
 ETC_HOSTS = ALL_NODES.map { |n| "#{n[:ip]} #{n[:name]}" }.join("\n") + "\n"
 
@@ -24,7 +25,6 @@ Vagrant.configure("2") do |config|
     config.vm.define node[:name] do |cplane|
       cplane.vm.box = node[:box]
       cplane.vm.network node[:network], ip: node[:ip]
-      cplane.vm.network "forwarded_port", guest: 443, host: 8443 # Port Forward for k8s dashboard
       cplane.vm.hostname = node[:name]
       cplane.vm.provider "virtualbox" do |v|
         v.name = node[:name]
@@ -32,86 +32,13 @@ Vagrant.configure("2") do |config|
         v.cpus = 2
       end
       cplane.vm.provision "shell",
-        env: {
-          "ETC_HOSTS"     => ETC_HOSTS,
-          "BASE_CIDR"     => BASE_CIDR,
-          "API_SERVER_IP" => node[:ip] # API Server is the control plane host itself
-        },
+        env: { "ETC_HOSTS" => ETC_HOSTS },
         inline: <<-SHELL
-        # Add Nodes to /etc/hosts
-        sudo echo "# Added by Vagrant" >> /etc/hosts
-        sudo echo "#" >> /etc/hosts
-        echo -e "${ETC_HOSTS}" | while read -r hline; do
-          sudo echo ${hline} >> /etc/hosts
-        done
+          # Provision the Control Plane (Base and Specific)
+          /vagrant/scripts/provision/provision_base.sh
+          [ -f "/vagrant/scripts/provision/provision_cplane.sh" ] && /vagrant/scripts/provision/provision_cplane.sh
 
-        # Create Cluster Init Script:
-        echo "#!/bin/bash"                                                     >  cluster_init.sh
-        echo "echo 'Pulling k8s Images'"                                       >> cluster_init.sh
-        echo "sudo kubeadm config images pull"                                 >> cluster_init.sh
-        echo "echo ''"                                                         >> cluster_init.sh
-        echo "echo 'Initializing Cluster'"                                     >> cluster_init.sh
-        echo "sudo kubeadm init --pod-network-cidr=${BASE_CIDR}/16 --apiserver-advertise-address=${API_SERVER_IP}" >> cluster_init.sh
-        echo "if [ -f /etc/kubernetes/admin.conf ] ; then"                     >> cluster_init.sh
-        echo "  echo ''"                                                       >> cluster_init.sh
-        echo "  echo 'Create local .kube/config'"                              >> cluster_init.sh
-        echo "  mkdir -p \\\${HOME}/.kube"                                     >> cluster_init.sh
-        echo "  sudo cp -i /etc/kubernetes/admin.conf \\\${HOME}/.kube/config" >> cluster_init.sh
-        echo "  sudo chown \\\$(id -u):\\\$(id -g) \\\${HOME}/.kube/config"    >> cluster_init.sh
-        echo "  echo ''"                                                       >> cluster_init.sh
-        echo "  echo 'Install Weave'"                                          >> cluster_init.sh
-        echo "  kubectl apply -f https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml" >> cluster_init.sh
-        echo "fi"                                                              >> cluster_init.sh
-        chmod a+rx cluster_init.sh
-
-        # Show the k8s join command:
-        echo "#!/bin/bash"                                     >  join_cmd.sh
-        echo "echo 'k8s worker join command (may need sudo):'" >> join_cmd.sh
-        echo "echo ''"                                         >> join_cmd.sh
-        echo "kubeadm token create --print-join-command"       >> join_cmd.sh
-        echo "echo ''"                                         >> join_cmd.sh
-        sudo chmod a+rx join_cmd.sh
-
-        # Apt Stuff:
-        sudo apt update
-        sudo apt install ca-certificates curl
-        sudo install -m 0755 -d /etc/apt/keyrings
-        sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-        sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-        # Add the repository to Apt sources:
-        echo \
-          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-        sudo apt update
-        sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-        sudo systemctl enable docker
-        sudo ufw disable
-        sudo swapoff -a
-        sudo apt update && sudo apt install -y apt-transport-https
-        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-        sudo apt update
-
-        # apt-transport-https may be a dummy package; if so, you can skip that package
-        sudo apt install -y apt-transport-https ca-certificates curl gpg
-        # Helm Deployment Manager
-        curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-        echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-        sudo apt update
-        sudo apt install -y helm
-
-        # Containerd
-        curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-        echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
-        sudo apt update
-        sudo apt install -y kubelet kubeadm kubectl
-        sudo apt-mark hold kubelet kubeadm kubectl
-        sudo systemctl enable --now kubelet
-        sudo containerd config default | sudo tee /etc/containerd/config.toml
-        sudo sed -i 's/            SystemdCgroup = false/            SystemdCgroup = true/' /etc/containerd/config.toml
-        sudo sed -i 's|sandbox_image = "registry.k8s.io/pause:3.8"|sandbox_image = "registry.k8s.io/pause:3.9"|g' /etc/containerd/config.toml
-        sudo systemctl restart containerd
+          cp -f /vagrant/scripts/cplane/*.sh . 2>/dev/null || true
         SHELL
     end
   end
@@ -130,44 +57,11 @@ Vagrant.configure("2") do |config|
       worker.vm.provision "shell",
         env: {"ETC_HOSTS" => ETC_HOSTS},
         inline: <<-SHELL
-        # Add Nodes to /etc/hosts
-        sudo echo "# Added by Vagrant" >> /etc/hosts
-        sudo echo "#" >> /etc/hosts
-        echo -e "${ETC_HOSTS}" | while read -r hline; do
-          sudo echo ${hline} >> /etc/hosts
-        done
-        # Apt Stuff:
-        sudo apt update
-        sudo apt install ca-certificates curl
-        sudo install -m 0755 -d /etc/apt/keyrings
-        sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-        sudo chmod a+r /etc/apt/keyrings/docker.asc
+          # Provision the Worker (Base and Specific)
+          /vagrant/scripts/provision/provision_base.sh
+          [ -f "/vagrant/scripts/provision/provision_worker.sh" ] && /vagrant/scripts/provision/provision_worker.sh
 
-        # Add the repository to Apt sources:
-        echo \
-          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-        sudo apt update
-        sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-        sudo systemctl enable docker
-        sudo ufw disable
-        sudo swapoff -a
-        sudo apt update && sudo apt install -y apt-transport-https
-        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-        sudo apt update
-        # apt-transport-https may be a dummy package; if so, you can skip that package
-        sudo apt install -y apt-transport-https ca-certificates curl gpg
-        curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-        echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
-        sudo apt update
-        sudo apt install -y kubelet kubeadm kubectl
-        sudo apt-mark hold kubelet kubeadm kubectl
-        sudo systemctl enable --now kubelet
-        sudo containerd config default | sudo tee /etc/containerd/config.toml
-        sudo sed -i 's/            SystemdCgroup = false/            SystemdCgroup = true/' /etc/containerd/config.toml
-        sudo sed -i 's|sandbox_image = "registry.k8s.io/pause:3.8"|sandbox_image = "registry.k8s.io/pause:3.9"|g' /etc/containerd/config.toml
-        sudo systemctl restart containerd
+          cp -f /vagrant/scripts/worker/*.sh . 2>/dev/null || true
         SHELL
     end
   end

--- a/instructions.txt
+++ b/instructions.txt
@@ -1,26 +1,21 @@
-TO SPEED UP THE PROCESS 1ST RUN in the master NODE-
+TO SPEED UP THE PROCESS 1ST RUN in the master NODE:
 - sudo kubeadm config images pull
 
-TO INIT, RUN  in the master NODE-
-- sudo kubeadm init --pod-network-cidr=10.201.0.0/16 --apiserver-advertise-address=192.168.63.1
-- you wull get a kubeadm join command run that in you master node after Install the CNI
+TO INIT, RUN  in the master NODE:
+- sudo kubeadm init --pod-network-cidr=10.201.0.0/16 --apiserver-advertise-address=192.168.63.11
+- you will get a kubeadm join command run that in you master node after Install the CNI
 
-TO INSTALL CNI (weave) -
-- kubectl apply -f https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml
+TO INSTALL CNI (weave):
+- sudo kubectl apply -f https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml
 
-IF face proble while jioning worker node, reatart master node and run below commands-
-sudo kubeadm reset
+If you face problems while joining a worker node, restart master node and run below commands:
+- sudo kubeadm reset
+- sudo swapoff -a => all nodes.
+- sudo systemctl restart kubelet
+- sudo iptables -F
+- sudo rm -rf /var/lib/cni/
+- sudo systemctl restart containerd
+- sudo systemctl daemon-reload
 
-sudo swapoff -a => all nodes.
+then try again to join... I hope it will work :')
 
-sudo systemctl restart kubelet
-
-sudo iptables -F
-
-sudo rm -rf /var/lib/cni/
-
-sudo systemctl restart containerd
-
-sudo systemctl daemon-reload
-
-then againg try to join... hope it will work :')

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,50 @@
+# Vagrant Kubernetes Cluster
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Vagrant](https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white)](https://www.vagrantup.com/)
+[![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)](https://kubernetes.io/)
+[![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)](https://ubuntu.com/)
+
+This project sets up a local Kubernetes cluster using Vagrant and VirtualBox. It creates two Ubuntu 24.04 virtual machines: one control plane node and one worker node with automatic installation of Docker, Kubernetes components, and necessary configurations.
+
+## Bash Scripts
+
+These scripts are to make it easy to bring up and maintain the Kubernetes Cluster.  Some are collections of manual provisioning commands from the original project (which reduces manual typing errors). Others are facilitators, to manage the Control Plane and Worker nodes in an easy and repeatable fashion.
+
+<table>
+<tr>
+    <td>🚜&nbsp;Provision</td>
+    <td>Package Installation and Service Management of Machines</td>
+</tr>
+<tr>
+    <td>🚀&nbsp;Cplane</td>
+    <td>To spin up and manage the Control Plane</td>
+</tr>
+<tr>
+    <td>🛠&nbsp;Worker</td>
+    <td>To join up and manage the Worker nodes</td>
+</tr>
+</table>
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+Copyright (c) 2024 Vagrant Kubernetes Cluster
+
+## 📫 Support & Contribution
+
+If you encounter any issues or need assistance:
+
+[![Create Issue](https://img.shields.io/badge/Create-Issue-green.svg)](https://github.com/yourusername/vagrant-kubernetes/issues/new)
+[![Pull Request](https://img.shields.io/badge/Pull-Request-blue.svg)](https://github.com/yourusername/vagrant-kubernetes/pulls)
+
+## 📝 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+---
+
+<div align="center">
+Made with ❤️ for the Kubernetes community
+</div>

--- a/scripts/cplane/README.md
+++ b/scripts/cplane/README.md
@@ -1,0 +1,54 @@
+# Vagrant Kubernetes Cluster
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Vagrant](https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white)](https://www.vagrantup.com/)
+[![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)](https://kubernetes.io/)
+[![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)](https://ubuntu.com/)
+
+This project sets up a local Kubernetes cluster using Vagrant and VirtualBox. It creates two Ubuntu 24.04 virtual machines: one control plane node and one worker node with automatic installation of Docker, Kubernetes components, and necessary configurations.
+
+## Control Plane Scripts
+
+🛠 These scripts are copied to - and executed on - the Control Plane. They are designed to make it easier to initialize the cluster, and set up some basic things
+
+<table>
+<tr>
+    <td>🚀&nbsp;cluster_init.sh</td>
+    <td>Initialize the Kubernetes Cluster and install the Weave CNI</td>
+</tr>
+<tr>
+    <td>🛠&nbsp;kube_dashboard.sh </td>
+    <td>Install the Kubernetes Dashboard</td>
+</tr>
+<tr>
+    <td>⚙️&nbsp;set_worker_role.sh</td>
+    <td>Define "worker" labels for each of the worker nodes in the Cluster</td>
+</tr>
+<tr>
+    <td>📜&nbsp;join_cmd.sh</td>
+    <td>Show the "join' information to be used on any worker nodes in the Cluster</td>
+</tr>
+</table>
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+Copyright (c) 2024 Vagrant Kubernetes Cluster
+
+## 📫 Support & Contribution
+
+If you encounter any issues or need assistance:
+
+[![Create Issue](https://img.shields.io/badge/Create-Issue-green.svg)](https://github.com/yourusername/vagrant-kubernetes/issues/new)
+[![Pull Request](https://img.shields.io/badge/Pull-Request-blue.svg)](https://github.com/yourusername/vagrant-kubernetes/pulls)
+
+## 📝 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+---
+
+<div align="center">
+Made with ❤️ for the Kubernetes community
+</div>

--- a/scripts/cplane/cluster_init.sh
+++ b/scripts/cplane/cluster_init.sh
@@ -266,6 +266,7 @@ function verify_flannel_cni {
         if [ ${flannel_state} == "Running" ]; then
             break
         elif [ ${elapsed} -lt ${timeout} ]; then
+            echo "⏳ Current State: '${flannel_state}', sleep and retry"
             sleep ${interval}
         fi
     done

--- a/scripts/cplane/cluster_init.sh
+++ b/scripts/cplane/cluster_init.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+
+#
+# Script to Initialize the Control Plane
+#
+# There is a lot in this script. If you're learning, don't be put off
+# look below for "SCRIPT ESSENTIALS" and it shows the small set of
+# important functions, which are:
+#
+# 1. Grab the kubernetes service images
+# 2. Init the service, specifying the base CIDR
+# 3. Copy the kube config to the user directory
+# 4. Install the CNI service
+#
+# Unicode Character icons (https://www.compart.com/en/unicode) for pretty scripts
+#
+# 😄 Generic Info
+# ☸️ Kubernetes
+# ✨ Perform Magic
+# ⚙️ Setting something
+# 🚜 Image pull
+# 🛠 Tools / Install
+# 🔍 Get Info or Data or Config
+# ✅ Good Result
+# ❌ Bad Result
+# ⬆ Up Arrow
+# ⬇ Down Arrow
+# ❓ Question / Unknown
+# 🤷 Something missing
+# 🔥 Creating something
+# 👍 Startup
+# ⏳ Waiting
+# 🔄 Restarting
+#
+
+# These variables define the Heart of the Cluster: CP ID and IP base for Pods
+#
+# Strip off errant 'localhost-y' reference that get created via vagrant
+API_SERVER_IP=$(echo $(hostname -i | sed -E 's/127\.0\.[0-9]+\.[0-9]+//g'))
+POD_BASE_CIDR=10.244.0.0 # Base address for pods
+
+# Hey, howzitgoing
+function welcome_msg {
+    echo "Kubernetes Control Plane / Cluster Init"
+    echo ""
+    echo "POD_BASE_CIDR: '${POD_BASE_CIDR}'"
+    echo "API_SERVER_IP: '${API_SERVER_IP}'"
+    echo ""
+}
+
+
+# Quick check to see if Kubernetes utilities are installed
+function kube_sanity_check {
+    # Are Kubernetes tools installed?
+    echo "🔍 Check for kubernetes tools on the machine"
+
+    kube_tools="kubelet kubeadm kubectl"
+    for ktool in $(echo ${kube_tools}); do
+        if ! command -v ${ktool} >/dev/null 2>&1; then
+            echo "🤷 utility '${ktool}' not found"
+            ktoolmissing=y
+        fi
+    done
+
+    if [ "${ktoolmissing}" == "y" ] ; then
+        echo "❌ one ore more kubernetes utilities missing; install before continuing"
+        exit 1
+    fi
+}
+
+
+# Verify that the api server is up and running ?
+# or all are down
+#
+# Param 1 - "up" or "down"
+# Param 2 - optional - "retry" for a retry loop, useful
+#           for when services are taking time to come up/down
+function verify_controlplane_state {
+    D_SOC=unix:///var/run/containerd/containerd.sock
+
+    state_check="${1,,}"
+    if ! [[ ${state_check} = @(up|down) ]]; then
+       echo "❌ Invalid parameter must be 'up' or 'down'"
+       exit 1
+    fi
+
+    # Option to allow for delayed retries (allow for services to come up/down)
+    if [ "${2,,}" == "retry" ]; then
+        timeout=60 # 1 minute = 60 seconds
+    else
+        timeout=0  # No loop; (or, just one iteration)
+    fi
+    interval=10
+    elapsed=0
+
+    # What services are we checking for?
+    kube_services="kube-apiserver kube-controller-manager kube-scheduler kube-proxy etcd"
+
+    # Find max svc name length (purely aesthetic)
+    maxlen=0
+    for kubsvc in $(echo ${kube_services}); do
+        [ ${#kubsvc} -gt ${maxlen} ] && maxlen=${#kubsvc}
+    done
+    maxlen=$((maxlen + 2))
+
+    # Repeat loop until time runs out
+    while [ ${elapsed} -lt ${timeout} ]; do
+        echo -n "🔍 Verify Kubernetes Services run state is '${state_check}'"
+        if [ ${elapsed} -gt 0 ]; then
+            echo " (trying for $((timeout - elapsed)) more seconds)"
+        else
+            echo ""
+        fi
+
+        # Clear up/down State Markers
+        ksvcup=""
+        ksvcdown=""
+
+        # Check state of each service
+        for kubsvc in $(echo ${kube_services}); do
+            SVC_STATE=$(sudo crictl --runtime-endpoint ${D_SOC} ps -o json --name "${kubsvc}" 2>/dev/null | jq -r ".containers[] | select(.metadata.name == \"${kubsvc}\") | .state")
+
+            # State Icons (actual vs compare) - Up, Down, or Unknown
+            # Also to create the "icon state" for each service (up/down and expectation)
+            if [ "${SVC_STATE}" == "CONTAINER_RUNNING" ]; then
+                ksvcup=y
+                state_str="up"
+                state_icon=$([ "${state_check}" == "up" ] && echo "⬆ ✅" || echo "⬆ ❌" )
+            elif [ "${SVC_STATE}" == "" ]; then
+                ksvcdown=y
+                state_str="down"
+                state_icon=$([ "${state_check}" == "down" ] && echo "⬇ ✅" || echo "⬇ ❌")
+            else
+                ksvcdown=y
+                state_str="down / uncertain (state: '${SVC_STATE}')"
+                state_icon="❓ ❌"
+            fi
+
+            printf "  %s Service %-*s: %s\n" "${state_icon}" "${maxlen}" "'${kubsvc}'" "${state_str}"
+        done
+
+        # Are service states matching expectations?
+        # - Going "up" but some services are still down?
+        # - Going "down" but some services are still up?
+        # - All good - All own or all up, as expected?
+        state_check="${1,,}"
+        if [ "${state_check}" == "up" ] && [ "${ksvcdown}" == "y" ] ; then
+            echo "❌ Expected state is UP but some services are not running"
+            exit_state=1
+        elif [ "${state_check}" == "down" ] && [ "${ksvcup}" == "y" ] ; then
+            echo "❌ Expected state is DOWN but some services are still running"
+            exit_state=1
+        else
+            echo "✅ Kubernetes Services in expected state: '${state_check}'"
+            exit_state=0
+            retries=0
+        fi
+
+        # If there is a retry to be had, notify, delay, and repeat
+        # a timeout of 0 means no loop, just break out
+        elapsed=$((elapsed + interval))
+        if [ "${exit_state}" == "0" ] || [ "${timeout}" == "0" ]; then
+            break
+        elif [ ${elapsed} -lt ${timeout} ]; then
+            echo "⏳ Retry - ${interval} second delay"
+            sleep ${interval}
+        fi
+    done
+
+    # didn't work; exit out
+    if [ "${exit_state}" == "1" ] ; then
+        exit 1
+    fi
+}
+
+#
+# SCRIPT ESSENTIALS ARE HERE
+#
+# There are many functions in this script that perform
+# a series of sanity checks and "extra" work, which is helpful
+# but not strictly necessary
+#
+# The ESSENTIAL work is right here:
+#   controlplane_init  - to start up the Control Plane
+#   kubeconf_copy      - to use 'kubectl' properly
+#   verify_flannel_cni - to set up cluster communication
+#
+# If you are trying to learn about Starting up a Kubernetes
+# Cluster, these are the essential functions
+#
+# If you are interested in creating solid service automation
+# the rest of the informative or sanity checking is very handy
+#
+
+# Initialize the Control Plane Cluster
+function controlplane_init {
+    # Pull down the Kubernetes images for Control Plane Initialization
+    echo "🚜  Pulling Kubernetes execution Images"
+    echo "--------------------------------------"
+    sudo kubeadm config images pull
+    echo "--------------------------------------"
+
+    # Spin up the Control Plane Node (the 'heart' of the Cluster)
+    echo "🔄  Initializing Cluster"
+    echo "--------------------------------------"
+    sudo kubeadm init --pod-network-cidr=${POD_BASE_CIDR}/16 --apiserver-advertise-address=${API_SERVER_IP}
+    echo "--------------------------------------"
+}
+
+
+# Copy the k8s admin.conf into the user directory for subsequent use
+function kubeconf_copy {
+    if [ -f /etc/kubernetes/admin.conf ] ; then
+        echo "⚙️  Create local '.kube/config'"
+        mkdir -p ${HOME}/.kube
+        sudo cp -f /etc/kubernetes/admin.conf ${HOME}/.kube/config
+        sudo chown $(id -u):$(id -g) ${HOME}/.kube/config
+    fi
+}
+
+
+# Install the Flannel CNI (Container Network Interface)
+function install_flannel_cni {
+    echo "🚜  Install Flannel CNI Service"
+
+    # The Prepackaged Flannel CNI is hard coded to use CIDR of 10.244.0.0/16
+    if ! [ "${POD_BASE_CIDR}" == "10.244.0.0" ]; then
+        echo "❌ For Flannel CNI via 'kubectl apply', var 'POD_BASE_CIDR' must be '10.244.0.0'"
+        echo "   (POD_BASE_CIDR is currently defined as '${POD_BASE_CIDR}')"
+        echo ""
+        exit 1
+    fi
+
+    # Install Flannel Service
+    echo "--------------------------------------"
+    kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml --validate=false
+    echo "--------------------------------------"
+
+    # Restart the kubelet
+    sudo service kubelet restart
+}
+
+
+# Verify the Flannel CNI Installation
+function verify_flannel_cni {
+    echo "🔍 Verify Flannel CNI Service Install"
+
+    # Verify that CNI service is running
+    timeout=60 # 1 minute = 60 seconds
+    interval=10 # check every 10 seconds
+    elapsed=0
+
+    # Repeat loop until time runs out
+    while [ ${elapsed} -lt ${timeout} ]; do
+        echo -n "🔍 Verify Flannel Service running"
+        if [ ${elapsed} -gt 0 ]; then
+            echo " (trying for $((timeout - elapsed)) more seconds)"
+        else
+            echo ""
+        fi
+
+        # If Flannel is running correctly then it will report back the pods list
+        flannel_state=$(kubectl get pods -n kube-flannel -o json 2>/dev/null | jq -r '.items[] | select(.metadata.name | startswith("kube-flannel-")) | .status.phase')
+
+        elapsed=$((elapsed + interval))
+        if [ ${flannel_state} == "Running" ]; then
+            break
+        elif [ ${elapsed} -lt ${timeout} ]; then
+            sleep ${interval}
+        fi
+    done
+
+    if [ ${flannel_state} == "Running" ]; then
+        echo "✅ Flannel CNI Service is running"
+    else
+        echo "❌ Timed out during check - Flannel CNI service is NOT running"
+        exit 1
+    fi
+}
+
+
+# Install the Weave CNI (Container Network Interface)
+# NOTE: Weave Project was Shuttered in June 2024 and no longer supported
+function install_weave_cni {
+    echo "🚜  Install Weave CNI Service"
+    echo "--------------------------------------"
+    kubectl apply -f https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml --validate=false
+    echo "--------------------------------------"
+}
+
+
+# Verify the Weave CNI Installation
+function verify_weave_cni {
+    echo "🔍 Verify Weave CNI Service Install"
+
+    # Verify that CNI service is running
+    timeout=60 # 2 minutes = 120 seconds
+    interval=10 # check every 10 seconds
+    elapsed=0
+
+    # Repeat loop until time runs out
+    while [ ${elapsed} -lt ${timeout} ]; do
+        echo -n "🔍 Verify Weave Service running"
+        if [ ${elapsed} -gt 0 ]; then
+            echo " (trying for $((timeout - elapsed)) more seconds)"
+        else
+            echo ""
+        fi
+
+        # If Weave is running correctly then it will report back the pods list
+        weave_count=$(kubectl get pods -n kube-system -o json 2>/dev/null | jq -r '.items[] | select(.metadata.name | startswith("weave-net-")) | .metadata.name' | wc -l)
+        elapsed=$((elapsed + interval))
+        if [ ${weave_count} -gt 0 ]; then
+            break
+        elif [ ${elapsed} -lt ${timeout} ]; then
+            sleep ${interval}
+        fi
+    done
+
+    if [ ${weave_count} -gt 0 ]; then
+        echo "✅ Weave CNI Service is running"
+    else
+        echo "❌ Timed out during check - Weave CNI service is NOT running"
+        exit 1
+    fi
+}
+
+
+# Install the Rancher LocalPath StorageClass implementation
+function install_localpath_storageclass {
+    echo "🚜  Install Rancher 'local-path' StorageClass"
+    echo "--------------------------------------"
+    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.32/deploy/local-path-storage.yaml --validate=false
+    echo "--------------------------------------"
+}
+
+
+#
+# Main Execution Loop
+#
+welcome_msg
+kube_sanity_check
+verify_controlplane_state down
+controlplane_init
+kubeconf_copy
+verify_controlplane_state up retry
+install_flannel_cni
+verify_flannel_cni
+#install_weave_cni
+#verify_weave_cni
+install_localpath_storageclass

--- a/scripts/cplane/join_cmd.sh
+++ b/scripts/cplane/join_cmd.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "k8s worker join command (requires sudo):"
+echo ""
+echo "--------------------------------------------------"
+echo -n "sudo "
+sudo kubeadm token create --print-join-command
+echo "--------------------------------------------------"
+echo ""
+

--- a/scripts/cplane/kube_dashboard.sh
+++ b/scripts/cplane/kube_dashboard.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+
+# Strip off errant 'localhost-y' reference that get created via vagrant
+CPLANE_IP=$(echo $(hostname -i | sed -E 's/127\.0\.[0-9]+\.[0-9]+//g'))
+
+# Kubernetes Dashboard Parameters
+NAMESPACE="kubernetes-dashboard"
+SERVICE="kubernetes-dashboard"
+DASHBOARD_PORT=32443
+
+function help_msg {
+    echo ""
+    echo "usage: ${0} [worker|cplane|token], where:"
+    echo "    worker - Deploy dashboard on any worker node"
+    echo "    cplane - Deploy dashboard on the control plane"
+    echo "    token  - Show the dashboard credentials token"
+    echo ""
+}
+
+
+# Quick check to see if Helm is installed, as
+# It is used for service deployments on the Control Plane
+function helm_sanity_check {
+    # Is Helm installed?
+    echo "🔍 Check for Helm tool on the machine"
+    if ! command -v helm >/dev/null 2>&1; then
+        echo "❌ Helm not found; install helm before continuing"
+        exit 1
+    fi
+}
+
+
+# Is the dashboard service up and running?
+function dashboard_sanity_check {
+    echo "🔍 Checking if Service '${SERVICE}' exists in namespace '${NAMESPACE}'..."
+    if ! kubectl get svc -n "${NAMESPACE}" "${SERVICE}" >/dev/null 2>&1; then
+        echo "❌ Service ${SERVICE} NOT found in namespace ${NAMESPACE}"
+        exit 1
+    else
+        echo "✅ Service ${SERVICE} found in namespace ${NAMESPACE}"
+    fi
+}
+
+
+# Configure the control plane to be the home of the Kubernetes Dashboard
+# This is just fine for a small deployment for development, however proper
+# HA configuration should be used for a larger cluster
+function dashboard_on_control_plane {
+    echo "⚙️  Configuring Control Plane to host the dashboard (as opposed to a worker)"
+    echo "🔍 Current Control Plane restrictions (Taints) - likely only 'NoSchedule'"
+
+    # should see "Taints: node-role.kubernetes.io/control-plane:NoSchedule"
+    kubectl describe node cplane | grep Taints
+
+    # remove taint for the dashboard (only):
+    echo "⚙️  Relaxing restriction (taint) on the control plane for '${SERVICE}'"
+    kubectl -n ${NAMESPACE} patch deployment ${SERVICE} \
+        --type='json' \
+        -p='[{"op":"add","path":"/spec/template/spec/tolerations","value":[{"key":"node-role.kubernetes.io/control-plane","effect":"NoSchedule"}]}]'
+
+    echo "🔍 Updated Control Plane restrictions (Taints)"
+    # should see "Taints: node-role.kubernetes.io/control-plane:NoSchedule"
+    kubectl describe node cplane | grep Taints
+    echo ""
+}
+
+
+# Install of Kubernetes Dashboard via the Helm Chart
+# (Which is now the official deployment method)
+function helm_dashboard_install {
+    echo "⚙️  Installing Kubernetes Dashboard (via helm)"
+    echo "⚙️  Add kubernetes-dashboard Helm repository"
+    helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+
+    echo "⚙️  Deploy 'kubernetes-dashboard' Helm chart"
+    helm upgrade --install ${SERVICE} kubernetes-dashboard/kubernetes-dashboard --create-namespace --namespace ${NAMESPACE}
+
+    echo "⚙️  Apply recommended manifests from the upstream project:"
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
+}
+
+
+# Create RBAC credential to access / admin via dashboard
+function dashboard_user_create {
+    echo "⚙️  Create user credentials for dashboard"
+    echo "⚙️  First, YAML file to create dashboard admin user"
+
+    #
+    # This creates the yaml file to instruct k8s in creating the dashboard space and the rbac access
+    # Do NOT modify or change the spacing between these lines!
+    #
+    # ----------------------------------------------
+    cat > dashboard-adminuser.yaml << EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: ${NAMESPACE}
+EOF
+# ----------------------------------------------
+#
+    echo "⚙️  Apply user create yaml to k8s"
+    kubectl apply -f dashboard-adminuser.yaml
+    rm -rf dashboard-adminuser.yaml
+}
+
+
+# Retrieve and display the dashboard credentials
+# And the url for login
+function dashboard_user_token {
+    echo "🔍 Retrieving the dashboard login token from k8s"
+    echo "⚙️  Copy and paste this to the 'Enter token *' field on the dashboard login"
+    echo "--------------------------------------------------"
+    kubectl -n ${NAMESPACE} create token admin-user
+    echo "--------------------------------------------------"
+    echo "Dashboard is at: https://${CPLANE_IP}:${DASHBOARD_PORT}"
+    echo ""
+}
+
+
+# Specific the specific port for the Dashboard
+# NodePort will otherwise choose a random port
+function dashboard_port_forward {
+    echo "⚙️  Setting up dashboard access via NodePort"
+    kubectl -n ${NAMESPACE} patch svc ${SERVICE} -p '{"spec": {"type": "NodePort"}}'
+
+    echo "🔍 Check Assigned NodePort:"
+    kubectl -n ${NAMESPACE} get svc ${SERVICE}
+
+    echo "⚙️  Patching service '${SERVICE}' to use nodePort=${DASHBOARD_PORT}..."
+    kubectl -n "${NAMESPACE}" patch svc "${SERVICE}" --type='json' -p="[
+        {
+            \"op\": \"replace\",
+            \"path\": \"/spec/ports/0/nodePort\",
+            \"value\": $((DASHBOARD_PORT))
+        },
+        {
+            \"op\": \"replace\",
+            \"path\": \"/spec/type\",
+            \"value\": \"NodePort\"
+        }
+    ]"
+
+    if [ $? -eq 0 ]; then
+        echo "✅ Dashboard is now exposed at: https://${CPLANE_IP}:${DASHBOARD_PORT}/"
+    else
+        echo "❌ Failed to patch the Service"
+        exit 1
+    fi
+
+    echo "🔍 New Assigned NodePort:"
+    kubectl -n ${NAMESPACE} get svc ${SERVICE}
+}
+
+
+#
+# Main Execution Loop
+#
+# Grab the command parameter
+param_str="${1,,}"
+if ! [[ ${param_str} = @(worker|cplane|token) ]]; then
+   echo "invalid parameter"
+   help_msg
+
+   exit 1
+fi
+
+if [[ ${param_str} = @(worker|cplane) ]]; then
+    echo "string found"
+    helm_sanity_check
+    helm_dashboard_install
+    dashboard_sanity_check
+
+    # cplane only
+    if [ "${param_str}" == "cplane" ]; then
+        dashboard_on_control_plane
+    fi
+
+    dashboard_user_create
+    dashboard_port_forward
+fi
+
+# Always show the user token
+dashboard_user_token

--- a/scripts/cplane/kube_dashboard.sh
+++ b/scripts/cplane/kube_dashboard.sh
@@ -173,12 +173,13 @@ function verify_kube_dashboard {
         fi
 
         # If the dashboard is running correctly then it will report back the pods list
-	dashboard_state=$(kubectl get pods -n ${NAMESPACE} -o json 2>/dev/null | jq -r '.items[] | select(.metadata.name | match("kubernetes-dashboard-[0-9a-f]{10}-[0-9a-f]")) | .status.phase')
+        dashboard_state=$(kubectl get pods -n ${NAMESPACE} -o json 2>/dev/null | jq -r '.items[] | select(.metadata.name | match("kubernetes-dashboard-[0-9a-z]{10}-[0-9a-z]{5}")) | .status.phase')
 
         elapsed=$((elapsed + interval))
         if [ "${dashboard_state}" == "Running" ]; then
             break
         elif [ ${elapsed} -lt ${timeout} ]; then
+            echo "⏳ Current State: '${dashboard_state}', sleep and retry"
             sleep ${interval}
         fi
     done

--- a/scripts/cplane/set_worker_role.sh
+++ b/scripts/cplane/set_worker_role.sh
@@ -1,26 +1,16 @@
 #!/usr/bin/env bash
 
-echo "⚙️  Setting worker node(s) role to 'worker'"
+echo "⚙️  Setting worker node(s) > 'node-role.kubernetes.io/worker=worker'"
 
-# Get list of nodes, look through the workers
+# Get list of nodes, run through the workers
 kub_nodes_json=`kubectl get nodes -o json`
 for node_name in `echo ${kub_nodes_json} | jq -r '.items[] | select(.metadata.name | startswith("worker")) | .metadata.name'` ; do
-
-    # Get the current role (if any) set for the worker node
-    node_role=`echo ${kub_nodes_json} | jq -r '.items[] | select(.metadata.name == "${node_name}") | .metadata.labels | to_entries[] | select(.key | startswith("node-role.kubernetes.io/worker")) | .value'`
-
-    # Only set the role if it's not already in place
-    echo "🔍 node role for '${node_name}': '${node_role}'"
-
-    if [ ! "${node_role}" == "worker" ] ; then
-        echo "⚙️  set worker node role for '${node_name}'"
-        kubectl label --overwrite node ${node_name} node-role.kubernetes.io/worker=worker >/dev/null
-   else
-        echo "  role 'worker' already set for node '${node_name}'"
-   fi
+     echo "⚙️  set worker node role for '${node_name}'"
+     kubectl label --overwrite node ${node_name} node-role.kubernetes.io/worker=worker >/dev/null
 done
 
 echo ""
-echo "🔍 k8s nodes with roles:"
-echo "---------------------"
+echo "🔍 Cluster nodes and roles:"
+echo "---------------------------"
 kubectl get nodes
+echo ""

--- a/scripts/cplane/set_worker_role.sh
+++ b/scripts/cplane/set_worker_role.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+echo "⚙️  Setting worker node(s) role to 'worker'"
+
+# Get list of nodes, look through the workers
+kub_nodes_json=`kubectl get nodes -o json`
+for node_name in `echo ${kub_nodes_json} | jq -r '.items[] | select(.metadata.name | startswith("worker")) | .metadata.name'` ; do
+
+    # Get the current role (if any) set for the worker node
+    node_role=`echo ${kub_nodes_json} | jq -r '.items[] | select(.metadata.name | startswith("worker")) | select(.metadata.name == "worker1") | .metadata.labels | to_entries[] | select(.key | startswith("node-role.kubernetes.io/worker")) | .value'`
+
+    # Only set the role if it's not already in place
+    echo "🔍 node role for '${node_name}': '${node_role}'"
+
+    if [ ! "${node_role}" == "worker" ] ; then
+        echo "⚙️  set worker node role for '${node_name}'"
+        kubectl label --overwrite node ${node_name} node-role.kubernetes.io/worker=worker >/dev/null
+   else
+        echo "  role 'worker' already set for node '${node_name}'"
+   fi
+done
+
+echo ""
+echo "🔍 k8s nodes with roles:"
+echo "---------------------"
+kubectl get nodes

--- a/scripts/cplane/set_worker_role.sh
+++ b/scripts/cplane/set_worker_role.sh
@@ -7,7 +7,7 @@ kub_nodes_json=`kubectl get nodes -o json`
 for node_name in `echo ${kub_nodes_json} | jq -r '.items[] | select(.metadata.name | startswith("worker")) | .metadata.name'` ; do
 
     # Get the current role (if any) set for the worker node
-    node_role=`echo ${kub_nodes_json} | jq -r '.items[] | select(.metadata.name | startswith("worker")) | select(.metadata.name == "worker1") | .metadata.labels | to_entries[] | select(.key | startswith("node-role.kubernetes.io/worker")) | .value'`
+    node_role=`echo ${kub_nodes_json} | jq -r '.items[] | select(.metadata.name == "${node_name}") | .metadata.labels | to_entries[] | select(.key | startswith("node-role.kubernetes.io/worker")) | .value'`
 
     # Only set the role if it's not already in place
     echo "🔍 node role for '${node_name}': '${node_role}'"

--- a/scripts/provision/README.md
+++ b/scripts/provision/README.md
@@ -1,0 +1,65 @@
+# Vagrant Kubernetes Cluster
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Vagrant](https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white)](https://www.vagrantup.com/)
+[![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)](https://kubernetes.io/)
+[![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)](https://ubuntu.com/)
+
+This project sets up a local Kubernetes cluster using Vagrant and VirtualBox. It creates two Ubuntu 24.04 virtual machines: one control plane node and one worker node with automatic installation of Docker, Kubernetes components, and necessary configurations.
+
+## System Provisioning Scripts
+
+🛠 These scripts perform System provisioning and of the Machines (VM or Bare Metal), such as
+* Package Repository management (adding new package sources)
+* Package installation or upgrade
+* Service start / restart
+
+Originally embedded in the project Vagrantfile, the work was separated out into these discrete Bash scripts to provide flexibility and consistency across the nodes.
+
+They are designed to make it easier to have a "baseline" installation of a collection of Kubernetes nodes - Control Plane or Worker - and to use the scripts in future projects outside of Vagrant / VirtualBox; provisioning bare metal machines, for example.
+
+<table>
+<tr>
+    <td>🚜&nbsp;provision_base.sh</td>
+    <td>Install packages and enable services that are on every Kubernetes node, whether Control Plane or Worker node</td>
+</tr>
+<tr>
+    <td>🚜&nbsp;provision_cplane.sh </td>
+    <td>Install packages and enable services that are specific to the Control Plane</td>
+</tr>
+<tr>
+    <td>🚜&nbsp;provision_worker.sh</td>
+    <td>Install packages and enable services that are specific to the Worker node</td>
+</tr>
+</table>
+
+## Future Use
+
+These scripts are designed to make it easier to have a "baseline" installation of a collection of Kubernetes nodes - Control Plane or Worker.  While tailored to this Github Project, it is possible (and encouraged) to use the scripts in future projects outside of Vagrant / VirtualBox; provisioning bare metal machines, for example.
+
+### Ubuntu-Specific
+
+While these scripts are written for Ubuntu, future work could include 'provision_base_DISTRO.sh' for provisioning on other Linux Distros (e.g. SUSE, RHEL, CentOS)
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+Copyright (c) 2024 Vagrant Kubernetes Cluster
+
+## 📫 Support & Contribution
+
+If you encounter any issues or need assistance:
+
+[![Create Issue](https://img.shields.io/badge/Create-Issue-green.svg)](https://github.com/yourusername/vagrant-kubernetes/issues/new)
+[![Pull Request](https://img.shields.io/badge/Pull-Request-blue.svg)](https://github.com/yourusername/vagrant-kubernetes/pulls)
+
+## 📝 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+---
+
+<div align="center">
+Made with ❤️ for the Kubernetes community
+</div>

--- a/scripts/provision/provision_base.sh
+++ b/scripts/provision/provision_base.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+#
+# This is the base machine config for any Kubernetes node,
+# Whether a Control Plane or a Worker Node
+#
+# For purpose-specific configuration, put that work in one of:
+#   - provision_cplane.sh
+#   - provision_worker.sh
+#
+
+# Add Node Host Name / IP Address to /etc/hosts
+if [[ -n "${ETC_HOSTS}" ]]; then
+  sudo echo "# Added by Vagrant" >> /etc/hosts
+  sudo echo "#" >> /etc/hosts
+  echo -e "${ETC_HOSTS}" | while read -r hline; do
+    sudo echo ${hline} >> /etc/hosts
+  done
+fi
+
+# Check for Kernel module 'br_netfilter' - Bridge Network Filter
+# IF needed, Enable (and persist) Kernel Module br_netfilter
+if [ "$(lsmod | grep br_netfilter)" == "" ]; then
+    sudo modprobe br_netfilter
+    sudo touch /etc/modules-load.d/br_netfilter.conf
+    sudo chmod 666 /etc/modules-load.d/br_netfilter.conf
+    sudo echo "br_netfilter" > /etc/modules-load.d/br_netfilter.conf
+    sudo chmod 644 /etc/modules-load.d/br_netfilter.conf
+fi
+
+# Apt Stuff for Docker Install
+sudo apt update
+sudo apt install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Install Docker and ContainerD as the container management tool
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl enable docker
+sudo ufw disable
+sudo swapoff -a
+sudo apt update && sudo apt install -y apt-transport-https
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo apt update
+
+# Install the main Kubernetes components
+sudo apt install -y ca-certificates curl gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo apt update
+sudo apt install -y kubelet kubeadm kubectl
+sudo apt-mark hold kubelet kubeadm kubectl
+sudo systemctl enable --now kubelet
+
+# Configure Containerd Daemon
+sudo containerd config default | sudo tee /etc/containerd/config.toml
+sudo sed -i 's/            SystemdCgroup = false/            SystemdCgroup = true/' /etc/containerd/config.toml
+sudo sed -i 's|sandbox_image = "registry.k8s.io/pause:3.8"|sandbox_image = "registry.k8s.io/pause:3.9"|g' /etc/containerd/config.toml
+sudo systemctl restart containerd

--- a/scripts/provision/provision_cplane.sh
+++ b/scripts/provision/provision_cplane.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+#
+# This is the custom config for a Kubernetes Control Plane node
+# For general node configuration, put that work in 'provision_base.sh'
+#
+
+# Install Helm Deployment Manager
+sudo apt install -y ca-certificates curl gpg
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+sudo apt update
+sudo apt install -y helm


### PR DESCRIPTION
A number of changes and additions:
* Refactor provisioning out of the Vagrant file and into a separate "provisioning" bash script
   * Consistent provisioning across all nodes (control plane or worker)
   * separate out purpose-specific (ie, control plane or worker) work into their own provisioning script
   * easier to expand in the future
   * can be used by other project for other work
   * can be extented to "architecture-specific" base configs
* add support scripts to run on control plane for important tasks (cluster init, join command)
  * ease of use without having to copy / paste commands
  * repeatable, consisent use through scripts 

The scripts are documented and should be easy to read
* Functions to separate out tasks
* each script has a "main execution point" at the end that calls each function
* functions can be commented out for debug purposes

Script to install the Kubernetes Dashboard
* excellent learning tool
* can be installed on the Control Plane, to limit worker node load
